### PR TITLE
readlinkf.sh: define functions to be run in a subshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@ Short code version has been temporarily removed. See [v1.0.0](https://github.com
 ### Usage
 
   1. `varname=$(readlinkf_* "<path>")` (assign to variable)
-  2. `(readlinkf_* "<path>")` (output to stdout)
-  3. `readlinkf_* "<path>"` (output to stdout, not recommended)
-
-Note: Usage 1 and 2 use subshells and therefore have no side effects. It does
-not change the current directory and any variables. Usage 3 has side effects.
+  2. `readlinkf_* "<path>"` (output to stdout)
 
 The maximum depth of symbolic links is 40. This value is the same as defined in Linux kernel 5.6. (See [MAXSYMLINKS](MAXSYMLINKS))
 However, `readlink -f` has not limitation. If you want to change, modify `max_symlinks` variable in these function.

--- a/readlinkf.sh
+++ b/readlinkf.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # POSIX compliant version
-readlinkf_posix() {
+readlinkf_posix() (
   [ "${1:-}" ] || return 1
   max_symlinks=40
   CDPATH='' # to avoid changing to an unexpected directory
@@ -34,10 +34,10 @@ readlinkf_posix() {
     target=${link#*" $target -> "}
   done
   return 1
-}
+)
 
 # readlink version
-readlinkf_readlink() {
+readlinkf_readlink() (
   [ "${1:-}" ] || return 1
   max_symlinks=40
   CDPATH='' # to avoid changing to an unexpected directory
@@ -65,7 +65,7 @@ readlinkf_readlink() {
     target=$(readlink -- "$target" 2>/dev/null) || break
   done
   return 1
-}
+)
 
 # Run as a command is an example.
 case ${0##*/} in (readlinkf_posix | readlinkf_readlink)


### PR DESCRIPTION
Functions can be defined to be run inside subshells so that they don't affect the environment. This pull request just changes the function definitions, and updates the README to reflect the change.
