### PR TITLE
Always run in a subshell

### DIFF
--- a/readlinkf.sh
+++ b/readlinkf.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # POSIX compliant version
-readlinkf_posix() {
+readlinkf_posix() (
   [ "${1:-}" ] || return 1
   max_symlinks=40
   CDPATH='' # to avoid changing to an unexpected directory
@@ -34,10 +34,10 @@ readlinkf_posix() {
     target=${link#*" $target -> "}
   done
   return 1
-}
+)
 
 # readlink version
-readlinkf_readlink() {
+readlinkf_readlink() (
   [ "${1:-}" ] || return 1
   max_symlinks=40
   CDPATH='' # to avoid changing to an unexpected directory
@@ -65,7 +65,7 @@ readlinkf_readlink() {
     target=$(readlink -- "$target" 2>/dev/null) || break
   done
   return 1
-}
+)
 
 # Run as a command is an example.
 case ${0##*/} in (readlinkf_posix | readlinkf_readlink)


### PR DESCRIPTION
Instead of requiring the user to run `readlinkf_*` in a subshell, this allows the natural syntax `readlinkf_* "<path>"` to be used **without** changing the calling shell's directory.

Subshell functions *are* POSIX-compliant:

[2.9.5 Function Definition Command](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_05)
...
The format of a function definition command is as follows:

fname ( ) compound-command [io-redirect ...]

[2.9.4 Compound Commands](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_04)
...
( compound-list )
    Execute compound-list in a subshell environment...
...
{ compound-list ; }
    Execute compound-list in the current process environment...